### PR TITLE
Add Prefix to avoid collision

### DIFF
--- a/Modules/ReallySimpleDatabase/ReallySimpleDatabase.psd1
+++ b/Modules/ReallySimpleDatabase/ReallySimpleDatabase.psd1
@@ -18,6 +18,9 @@ ModuleVersion = '1.0'
 # Unique Module ID
 GUID = '39538ca5-9ed9-4ee2-945e-393c246ac916'
 
+# Prefix
+Prefix = 'Simple'
+
 # Module Author
 Author = 'Dr. Tobias Weltner'
 


### PR DESCRIPTION
`Open-Database`, etc. are potentially common cmdlets that may conflict. Add a default prefix so that it becomes `Open-SimpleDatabase`, etc.

No internal function names have to change.

Reference: https://docs.microsoft.com/en-us/powershell/scripting/developer/module/how-to-write-a-powershell-module-manifest?view=powershell-7.1#module-manifest-elements (At bottom)